### PR TITLE
Fix controller tests

### DIFF
--- a/src/bcccp/carpark/Carpark.java
+++ b/src/bcccp/carpark/Carpark.java
@@ -93,27 +93,6 @@ public class Carpark implements ICarpark {
     return adhocTicketDAO.findTicketByBarcode(barcode);
   }
 
-//  @Override
-//  public float calculateAddHocTicketCharge(long entryDateTime) {
-//    // Calculation: get current Date and Time, subtract entryDateTime, multiply result by
-//    // the $ charge rate and return charge. Assumption that rates are a fixed rate of $5.00 per hour.
-//    // Convert time to hours by dividing by 60,000. Assumption this is short-stay tariff car park.
-//
-//    final BigDecimal OUT_OF_HOURS_RATE = new BigDecimal(2.0);
-//
-//    final BigDecimal BUSINESS_HOURS_RATE = new BigDecimal(5.0);
-//
-//    final BigDecimal START_BUS_HOURS = new BigDecimal(7.0);
-//
-//    final BigDecimal END_BUS_HOURS = new BigDecimal(19.0);
-//
-//    Date dateTime = new Date();
-//
-//    float chargeAmount = (dateTime.getTime() - entryDateTime) * rates / 60000;
-//
-//    return chargeAmount;
-//  }
-
   @Override
   public void recordAdhocTicketExit() {
 

--- a/src/bcccp/carpark/entry/EntryController.java
+++ b/src/bcccp/carpark/entry/EntryController.java
@@ -342,12 +342,12 @@ public class EntryController implements ICarSensorResponder, ICarparkObserver, I
     System.out.println("EntryController : " + message);
   }
 
-  public STATE getState() {
-    return state;
+  public String getState() {
+    return state.toString();
   }
 
-  public STATE getPreviousState() {
-    return prevState;
+  public String getPreviousState() {
+    return prevState.toString();
   }
 
 }

--- a/src/bcccp/carpark/exit/ExitController.java
+++ b/src/bcccp/carpark/exit/ExitController.java
@@ -292,12 +292,12 @@ public class ExitController implements ICarSensorResponder, IExitController {
         return barcode.substring(0, 1).equals("A");
   }
 
-    public STATE getState() {
-        return state;
+    public String getState() {
+        return state.toString();
     }
 
-    public STATE getPrevState() {
-        return prevState;
+    public String getPrevState() {
+        return prevState.toString();
     }
 
 }


### PR DESCRIPTION
This request includes significant modifications to the tests for Entry Controller and Exit Controller to enable controller states to be queried and also greater coverage of conditions. It also includes other modules that are associated with these controllers. Classes in this request include:
EntryController
ExitController
Carpark
EntryControllerTest
ExitControllerTest